### PR TITLE
[BUGFIX] Use database connection parameters

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -10,11 +10,13 @@ APP_SECRET=2e247e9836d54fdb539f58ad51e52310
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###
-# Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
-# Configure your db driver and server_version in config/packages/doctrine.yaml
-DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
-DATABASE_URL_TEST=mysql://bob:n0p455@127.0.0.1:3306/bob_test
+DATABASE_DRIVER=pdo_mysql
+DATABASE_SERVER_VERSION=5.7
+DATABASE_HOST=127.0.0.1
+DATABASE_PORT=3306
+DATABASE_NAME=bob_dev
+DATABASE_USER=bob
+DATABASE_PASSWORD=n0p455
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###

--- a/circle.yml
+++ b/circle.yml
@@ -44,10 +44,6 @@ jobs:
       - run:
           name: PHPUnit
           command: ./vendor/bin/simple-phpunit
-
-      - run:
-          name: Php-cs-fixer
-          command: php vendor/bin/php-cs-fixer fix --dry-run --diff
           
       - save_cache:
           key: cache-v1-{{ checksum "composer.lock" }}

--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,13 @@ jobs:
           - APP_ENV=test
           - APP_DEBUG=1
           - APP_SECRET=123
-          - DATABASE_URL=mysql://bob:n0p455@127.0.0.1:3306/bob_test
-          - DATABASE_URL_TEST=mysql://bob:n0p455@127.0.0.1:3306/bob_test
+          - DATABASE_DRIVER=pdo_mysql
+          - DATABASE_SERVER_VERSION=5.7
+          - DATABASE_HOST=127.0.0.1
+          - DATABASE_PORT=3306
+          - DATABASE_NAME=bob_test
+          - DATABASE_USER=bob
+          - DATABASE_PASSWORD=n0p455
       - image: mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=n0p455
@@ -40,6 +45,10 @@ jobs:
           name: PHPUnit
           command: ./vendor/bin/simple-phpunit
 
+      - run:
+          name: Php-cs-fixer
+          command: php vendor/bin/php-cs-fixer fix --dry-run --diff
+          
       - save_cache:
           key: cache-v1-{{ checksum "composer.lock" }}
           paths:

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,19 +1,15 @@
 parameters:
-    # Adds a fallback DATABASE_URL if the env var is not set.
-    # This allows you to run cache:warmup even if your
-    # environment variables are not available yet.
-    # You should not need to change this value.
-    env(DATABASE_URL): ''
 
 doctrine:
     dbal:
-        # configure these for your database server
-        driver: 'pdo_mysql'
-        server_version: '5.7'
-        charset: utf8mb4
-
-        # With Symfony 3.3, remove the `resolve:` prefix
-        url: '%env(resolve:DATABASE_URL)%'
+      driver:   '%env(DATABASE_DRIVER)%'
+      host:     '%env(DATABASE_HOST)%'
+      port:     '%env(DATABASE_PORT)%'
+      dbname:   '%env(DATABASE_NAME)%'
+      user:     '%env(DATABASE_USER)%'
+      password: '%env(DATABASE_PASSWORD)%'
+      charset:  utf8mb4
+      server_version: '%env(DATABASE_SERVER_VERSION)%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/config/packages/test/doctrine.yaml
+++ b/config/packages/test/doctrine.yaml
@@ -1,3 +1,3 @@
 doctrine:
     dbal:
-        url: '%env(resolve:DATABASE_URL_TEST)%'
+        dbname: 'bob_test'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,13 @@
         <!-- Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url -->
         <!-- For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db" -->
         <!-- Configure your db driver and server_version in config/packages/doctrine.yaml -->
-        <env name="DATABASE_URL_TEST" value="mysql://bob:n0p455@127.0.0.1:3306/bob_test"/>
+        <env name="DATABASE_DRIVER" value="pdo_mysql"/>
+        <env name="DATABASE_SERVER_VERSION" value="5.7"/>
+        <env name="DATABASE_HOST" value="127.0.0.1"/>
+        <env name="DATABASE_PORT" value="3306"/>
+        <env name="DATABASE_NAME" value="bob_test"/>
+        <env name="DATABASE_USER" value="bob"/>
+        <env name="DATABASE_PASSWORD" value="n0p455"/>
         <!-- ###- doctrine/doctrine-bundle ### -->
 
         <!-- ###+ symfony/swiftmailer-bundle ### -->


### PR DESCRIPTION
[BREAKING CHANGE]

Symfony 4 decided to use connection strings instead of connection parameters which makes life much harder: separating just dev/test db names is painfull.

This PR introduces parameters and has added doctrine config to test env to force test database name.

Also developers need to update `.env`, replacing:

```
###> doctrine/doctrine-bundle ###
# Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
# Configure your db driver and server_version in config/packages/doctrine.yaml
DATABASE_URL=mysql://bob:n0p455@localhost:3306/bob_dev
###< doctrine/doctrine-bundle ###
```

```
###> doctrine/doctrine-bundle ###
DATABASE_DRIVER=pdo_mysql
DATABASE_SERVER_VERSION=5.7
DATABASE_HOST=127.0.0.1
DATABASE_PORT=3306
DATABASE_NAME=bob_dev
DATABASE_USER=root
DATABASE_PASSWORD=n0p455
###< doctrine/doctrine-bundle ###
```

Closes #136