### PR TITLE
BUGFIX: Fix hardcoded TO email address

### DIFF
--- a/src/Service/ApplicantInviteEmailService.php
+++ b/src/Service/ApplicantInviteEmailService.php
@@ -45,7 +45,7 @@ class ApplicantInviteEmailService
 
         $message = (new \Swift_Message('Wellcome to Null training - TEAM 3'))
             ->setFrom('team3.nt@gmail.com')
-            ->setTo('leonard.vujanic@gmail.com')
+            ->setTo($entity->getContactEmailAddress())
             ->setBody($body, 'text/html');
 
         $this->mailer->send($message);


### PR DESCRIPTION
There is a hardcoded email address in ApplicantInviteEmailService , so now all emails go to Leo instead of aplicant :)

Closes #160